### PR TITLE
feat: Add additional ingress rules for ArgoCD, SonarQube, Prometheus,…

### DIFF
--- a/terraform/modules/security_group/main.tf
+++ b/terraform/modules/security_group/main.tf
@@ -51,6 +51,38 @@ resource "aws_security_group" "bastion_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Jenkins access"
   }
+  // Add ArgoCD Port
+  ingress {
+    from_port   = 8443
+    to_port     = 8443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "ArgoCD access"
+  }
+  // Add SonarQube Port
+  ingress {
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "SonarQube access"
+  }
+  // Add Prometheus Port
+  ingress {
+    from_port   = 9090
+    to_port     = 9090
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Prometheus access"
+  }
+  // Add Grafana Port
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Grafana access"
+  }
 
   // Add HTTP/HTTPS ports for web access
   ingress {


### PR DESCRIPTION
… and Grafana access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new security group rules to allow access to ArgoCD (port 8443), SonarQube (port 9000), Prometheus (port 9090), and Grafana (port 3000) from any IPv4 address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->